### PR TITLE
Meta viewport tag

### DIFF
--- a/template.php
+++ b/template.php
@@ -34,7 +34,6 @@ function ocha_basic_preprocess_html(&$vars) {
         'content' => 'width=device-width, initial-scale=1.0',
       ),
     );
-    drupal_add_html_head($viewport, 'viewport');
 
     $apple = array(
       '#tag' => 'link',
@@ -44,7 +43,6 @@ function ocha_basic_preprocess_html(&$vars) {
         'sizes' => '180x180'
       ),
     );
-    drupal_add_html_head($apple, 'apple-touch-icon');
 
     $fav_32 = array(
       '#tag' => 'link',
@@ -55,7 +53,6 @@ function ocha_basic_preprocess_html(&$vars) {
         'type' => 'image/png'
       ),
     );
-    drupal_add_html_head($fav_32, 'favicon-32x32');
 
     $fav_16 = array(
       '#tag' => 'link',
@@ -66,7 +63,6 @@ function ocha_basic_preprocess_html(&$vars) {
         'type' => 'image/png'
       ),
     );
-    drupal_add_html_head($fav_16, 'favicon-16x16');
 
     $safari_pinned_tab = array(
       '#tag' => 'link',
@@ -76,6 +72,11 @@ function ocha_basic_preprocess_html(&$vars) {
         'color' => '#5bbad5'
       ),
     );
+
+    drupal_add_html_head($viewport, 'viewport');
+    drupal_add_html_head($apple, 'apple-touch-icon');
+    drupal_add_html_head($fav_32, 'favicon-32x32');
+    drupal_add_html_head($fav_16, 'favicon-16x16');
     drupal_add_html_head($safari_pinned_tab, 'safari_pinned_tab');
 }
 

--- a/template.php
+++ b/template.php
@@ -27,6 +27,15 @@ function ocha_basic_preprocess_search_block_form(&$vars) {
 }
 
 function ocha_basic_preprocess_html(&$vars) {
+    $viewport = array(
+      '#tag' => 'meta',
+      '#attributes' => array(
+        'name' => 'viewport',
+        'content' => 'width=device-width, initial-scale=1.0',
+      ),
+    );
+    drupal_add_html_head($viewport, 'viewport');
+
     $apple = array(
       '#tag' => 'link',
       '#attributes' => array(
@@ -36,6 +45,7 @@ function ocha_basic_preprocess_html(&$vars) {
       ),
     );
     drupal_add_html_head($apple, 'apple-touch-icon');
+
     $fav_32 = array(
       '#tag' => 'link',
       '#attributes' => array(
@@ -46,6 +56,7 @@ function ocha_basic_preprocess_html(&$vars) {
       ),
     );
     drupal_add_html_head($fav_32, 'favicon-32x32');
+
     $fav_16 = array(
       '#tag' => 'link',
       '#attributes' => array(
@@ -56,6 +67,7 @@ function ocha_basic_preprocess_html(&$vars) {
       ),
     );
     drupal_add_html_head($fav_16, 'favicon-16x16');
+
     $safari_pinned_tab = array(
       '#tag' => 'link',
       '#attributes' => array(

--- a/templates/html.tpl.php
+++ b/templates/html.tpl.php
@@ -14,7 +14,6 @@
   <title><?php print $head_title; ?></title>
   <?php print $styles; ?>
   <?php print $scripts; ?>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600" rel="stylesheet">
   <!--[if lt IE 9]>
     <script src="https://cdn.jsdelivr.net/html5shiv/3.7.3/html5shiv.min.js"></script>


### PR DESCRIPTION
Short and sweet PR. I noticed the viewport tag is hardcoded within the theme. I switched it to use `drupal_add_html_head()` alongside the favicons.

## Testing

Just ensure a fresh install of theme still provides responsive layout. Viewing source will show that the tag now appears amongst the icon markup instead of appearing below styles/scripts.