### PR TITLE
Only commit compiled CSS during precommit hook

### DIFF
--- a/.githooks/pre-commit/pre-commit.sh
+++ b/.githooks/pre-commit/pre-commit.sh
@@ -9,4 +9,4 @@ export NODE_ENV='production'
 
 # build assets
 gulp build
-git add css js
+git add css/styles.css


### PR DESCRIPTION
I became slightly annoyed with the behavior or this precommit hook and feel it's far too broad. The old behavior committed all changes found in `css` and `js` directories. The new hook will only add compiled CSS found at `css/styles.css` to whatever is staged beforehand.

## Testing

* checkout PR branch
* Run `npm install` (this will install new version of the githook)
* Make a fake commit to try out new behavior. Change `css/styles.scss` (SCSS extension) and make a commit. The change should still be in your working directory after committing.