### PR TITLE
Suppress localConfig warning on production/Travis

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,8 +31,10 @@ try {
   localConfig = require('./localConfig.json');
 }
 catch (err) {
-  log(c.bgRed.white('localConfig.json is missing'));
-  log(c.red('Copy localConfig.example.json to localConfig.json and configure for your Drupal environment.'));
+  if (process.env.NODE_ENV !== 'production') {
+    log(c.bgRed.white('localConfig.json is missing'));
+    log(c.red('Copy localConfig.example.json to localConfig.json and configure for your Drupal environment.'));
+  }
 }
 
 


### PR DESCRIPTION
This warning is unnecessary on Travis/staging/prod so I'm suppressing the warning to avoid any confusion when someone reads through the logs.