### PR TITLE
CKEditor styles

### DIFF
--- a/ckeditor.styles.js
+++ b/ckeditor.styles.js
@@ -1,0 +1,30 @@
+/*
+Copyright (c) 2003-2013, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.html or http://ckeditor.com/license
+*/
+
+/*
+ * This file is used/requested by the 'Styles' button.
+ * The 'Styles' button is not enabled by default in DrupalFull and DrupalFiltered toolbars.
+ */
+if (typeof(CKEDITOR) !== 'undefined') {
+  CKEDITOR.addStylesSet('drupal',
+    [
+      /* Block Styles */
+
+      // These styles are already available in the "Format" drop-down list, so they are
+      // not needed here by default. You may enable them to avoid placing the
+      // "Format" drop-down list in the toolbar, maintaining the same features.
+
+      {name: 'Paragraph', element: 'p'},
+      {name: 'Heading 1', element: 'h1'},
+      {name: 'Heading 2', element: 'h2'},
+      {name: 'Heading 3', element: 'h3'},
+      {name: 'Heading 4', element: 'h4'},
+      {name: 'Heading 5', element: 'h5'},
+      {name: 'Heading 6', element: 'h6'},
+      {name: 'Preformatted Text', element: 'pre'},
+      {name: 'Address', element: 'address'}
+
+    ]);
+}


### PR DESCRIPTION
JS file override with list of html tags available in styles select list in WYSIWYG
Allows us to use the style dropdown in the WYSIWYG with a specific list of options

![ckeditor-styles](https://user-images.githubusercontent.com/1835923/45016902-64baa700-b026-11e8-9516-060ac31c3712.png)

The CKEditor settings look for this file by default
![ckeditor-css-settings](https://user-images.githubusercontent.com/1835923/45016973-96cc0900-b026-11e8-8e4a-8c9abed74a8e.png)
