### PR TITLE
[OPS-5170] Add an advanced theme setting to toggle debug on and off.

### DIFF
--- a/ocha_basic.info
+++ b/ocha_basic.info
@@ -44,3 +44,8 @@ modernizr[tests][] = flexbox
 modernizr[tests][] = mediaqueries
 modernizr[tests][] = svg
 modernizr[tests][] = setclasses
+
+; ========================================
+; Advanced Theme Settings
+; ========================================
+settings[ocha_basic_debug] = 0

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @file
+ * Theme setting callbacks for the ocha_basic theme.
+ */
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * @param $form
+ *   The form.
+ * @param $form_state
+ *   The form state.
+ */
+function ocha_basic_form_system_theme_settings_alter(&$form, &$form_state) {
+  $form['ocha_basic_debug'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable theme debugging'),
+    '#default_value' => theme_get_setting('ocha_basic_debug'),
+    '#description' => t('To help with theme development, you can enable or disable theme debugging.'),
+    '#weight' => -2,
+  );
+}


### PR DESCRIPTION
In the templates, you can check 
```php
if (theme_get_setting('ocha_basic_debug') == TRUE) {
  foobar_debug_output();
}
```