### PR TITLE
CD-102 Mobile menu should close when inline search is open

### DIFF
--- a/js/custom-menu.js
+++ b/js/custom-menu.js
@@ -26,7 +26,7 @@
           });
 
           // When bootstrap dropdown elements are clicked, close mobile menu.
-          $('.cd-global-header__dropdown-btn, .cd-search_btn').on('click.bs.dropdown', function(e) {
+          $('.cd-global-header__dropdown-btn, .cd-search_btn, .cd-search--inline_btn').on('click.bs.dropdown', function(e) {
             $('.cd-site-header__nav-holder').removeClass('open');
           });
 


### PR DESCRIPTION
include inline search button selector for click handler to close mobile menu when inline search is open