### PR TITLE
CD-81 replace ID selectors with classes

### DIFF
--- a/js/custom-search--inline.js
+++ b/js/custom-search--inline.js
@@ -9,9 +9,9 @@
 
       // Apply focus to input when dropdown is shown, remove when closed.
       $('.cd-search--inline').on('shown.bs.dropdown', function () {
-        $(this).find('#edit-search-api-views-fulltext').focus();
+        $(this).find('.cd-search--inline__input').focus();
       }).on('hidden.bs.dropdown', function () {
-        $(this).find('#edit-search-api-views-fulltext').blur();
+        $(this).find('.cd-search--inline__input').blur();
       });
 
       // Add class on submit button when input has focus, remove on blur.

--- a/js/custom-search.js
+++ b/js/custom-search.js
@@ -9,9 +9,9 @@
 
       // Apply focus to input when dropdown is shown.
       $('.cd-search').on('shown.bs.dropdown', function () {
-        $(this).find('#cd-search').focus();
+        $(this).find('.cd-search__input').focus();
       }).on('hidden.bs.dropdown', function () {
-        $(this).find('#cd-search').blur();
+        $(this).find('.cd-search__input').blur();
       });
 
       $('.cd-search__input').on('focus', function (e) {


### PR DESCRIPTION
As per [CD-81](https://humanitarian.atlassian.net/browse/CD-81)

Why have IDs when classes will do. Should result in no change. Search and Inline search should work as normal on dev and demo site.